### PR TITLE
Updates stat-boosting buffs so that they no longer require a target.

### DIFF
--- a/cmds/spells/b/_bears_endurance.c
+++ b/cmds/spells/b/_bears_endurance.c
@@ -13,7 +13,7 @@ void create() {
     set_spell_level(([ "ranger" : 2, "cleric" : 2,"druid" : 2, "assassin" : 2, "mage" : 2, "magus" : 2 ]));
     set_spell_sphere("alteration");
     set_bonus_type("enhancement");
-    set_syntax("cast CLASS bears endurance on TARGET");
+    set_syntax("cast CLASS bears endurance [on TARGET]");
     set_description("This spell allows the caster to infuse their target with the endurance of a bear, granting them a +4 enhancement bonus to constitution.");
     set_verbal_comp();
     set_somatic_comp();

--- a/cmds/spells/b/_bears_endurance.c
+++ b/cmds/spells/b/_bears_endurance.c
@@ -17,8 +17,7 @@ void create() {
     set_description("This spell allows the caster to infuse their target with the endurance of a bear, granting them a +4 enhancement bonus to constitution.");
     set_verbal_comp();
     set_somatic_comp();
-    set_target_required(1);
-	set_helpful_spell(1);
+    set_helpful_spell(1);
 }
 
 void spell_effect(int prof) {
@@ -29,6 +28,11 @@ void spell_effect(int prof) {
         return;
     }
     if (objectp(place)) place = environment(caster);
+	
+    if(!target)
+    {
+        target = caster;
+    }
     /*
     if((int)target->query_property("augmentation")){
       tell_object(caster,"%^YELLOW%^"+target->QCN+" is already under the influence of a similar spell.");

--- a/cmds/spells/b/_bulls_strength.c
+++ b/cmds/spells/b/_bulls_strength.c
@@ -13,7 +13,7 @@ void create()
     set_spell_level(([ "paladin" : 2, "cleric" : 2,"druid" : 2, "mage" : 2,"paladin":2, "magus" : 2 ]));
     set_spell_sphere("alteration");
     set_bonus_type("enhancement");
-    set_syntax("cast CLASS bulls strength on TARGET");
+    set_syntax("cast CLASS bulls strength [on TARGET]");
     set_description("This spell allows the caster to infuse their target with the strength of a bull, granting a +4 enhancement bonus to strength.");
     set_verbal_comp();
     set_somatic_comp();

--- a/cmds/spells/b/_bulls_strength.c
+++ b/cmds/spells/b/_bulls_strength.c
@@ -17,7 +17,6 @@ void create()
     set_description("This spell allows the caster to infuse their target with the strength of a bull, granting a +4 enhancement bonus to strength.");
     set_verbal_comp();
     set_somatic_comp();
-    set_target_required(1);
     set_helpful_spell(1);
 }
 
@@ -29,6 +28,11 @@ void spell_effect(int prof)
         return;
     }
     if(objectp(place)) place = environment(caster);
+    
+    if(!target)
+    {
+        target = caster;
+    }
 
     /*
     if((int)target->query_property("augmentation"))

--- a/cmds/spells/c/_cats_grace.c
+++ b/cmds/spells/c/_cats_grace.c
@@ -13,7 +13,7 @@ void create() {
     set_spell_level(([ "ranger" : 2, "bard" : 2,"druid" : 2, "assassin" : 2, "mage" : 2, "magus" : 2 ]));
     set_spell_sphere("alteration");
     set_bonus_type("enhancement");
-    set_syntax("cast CLASS cats grace on TARGET");
+    set_syntax("cast CLASS cats grace [on TARGET]");
     set_description("This spell allows the caster to infuse their target with the grace of a feline, granting them improved agility and coordination, granting them a +4 enhancement bonus to dexterity.");
     set_verbal_comp();
     set_somatic_comp();

--- a/cmds/spells/c/_cats_grace.c
+++ b/cmds/spells/c/_cats_grace.c
@@ -17,7 +17,6 @@ void create() {
     set_description("This spell allows the caster to infuse their target with the grace of a feline, granting them improved agility and coordination, granting them a +4 enhancement bonus to dexterity.");
     set_verbal_comp();
     set_somatic_comp();
-    set_target_required(1);
     set_helpful_spell(1);
 }
 
@@ -29,6 +28,11 @@ void spell_effect(int prof) {
         return;
     }
     if (objectp(place)) place = environment(caster);
+    
+    if(!target)
+    {
+        target = caster;
+    }
     /*
     if((int)target->query_property("augmentation")){
       tell_object(caster,"%^YELLOW%^"+target->QCN+" is already under the influence of a similar spell.");

--- a/cmds/spells/e/_eagles_splendor.c
+++ b/cmds/spells/e/_eagles_splendor.c
@@ -12,7 +12,7 @@ void create() {
     set_spell_level(([ "paladin" : 2, "bard" : 2, "cleric" : 2, "mage" : 2,"paladin":2 ]));
     set_spell_sphere("alteration");
     set_bonus_type("enhancement");
-    set_syntax("cast CLASS eagles splendor on TARGET");
+    set_syntax("cast CLASS eagles splendor [on TARGET]");
     set_description("This spell allows the caster to infuse their target with the presence of an eagle, enhancing their force of personality.  This spell doesn't stack with similarly powerful spells of enhancement.");
     set_verbal_comp();
     set_somatic_comp();

--- a/cmds/spells/e/_eagles_splendor.c
+++ b/cmds/spells/e/_eagles_splendor.c
@@ -16,8 +16,7 @@ void create() {
     set_description("This spell allows the caster to infuse their target with the presence of an eagle, enhancing their force of personality.  This spell doesn't stack with similarly powerful spells of enhancement.");
     set_verbal_comp();
     set_somatic_comp();
-    set_target_required(1);
-	set_helpful_spell(1);
+    set_helpful_spell(1);
 }
 
 void spell_effect(int prof) {
@@ -26,6 +25,11 @@ void spell_effect(int prof) {
         return;
     }
     if (objectp(place)) place = environment(caster);
+
+    if(!target)
+    {
+        target = caster;
+    }
     /*
     if((int)target->query_property("augmentation")){
       tell_object(caster,"%^YELLOW%^"+target->QCN+" is already under the influence of a similar spell.");

--- a/cmds/spells/f/_foxs_cunning.c
+++ b/cmds/spells/f/_foxs_cunning.c
@@ -12,7 +12,7 @@ void create() {
     set_spell_level(([ "bard" : 2, "assassin" : 2, "mage" : 2, "magus" : 2 ]));
     set_spell_sphere("alteration");
     set_bonus_type("enhancement");
-    set_syntax("cast CLASS foxs cunning on TARGET");
+    set_syntax("cast CLASS foxs cunning [on TARGET]");
     set_description("This spell allows the caster to infuse their target with the slyness of a fox, granting them a +4 enhancement bonus to intelligence.");
     set_verbal_comp();
     set_somatic_comp();

--- a/cmds/spells/f/_foxs_cunning.c
+++ b/cmds/spells/f/_foxs_cunning.c
@@ -16,7 +16,6 @@ void create() {
     set_description("This spell allows the caster to infuse their target with the slyness of a fox, granting them a +4 enhancement bonus to intelligence.");
     set_verbal_comp();
     set_somatic_comp();
-    set_target_required(1);
     set_helpful_spell(1);
 }
 

--- a/cmds/spells/f/_foxs_cunning.c
+++ b/cmds/spells/f/_foxs_cunning.c
@@ -17,7 +17,7 @@ void create() {
     set_verbal_comp();
     set_somatic_comp();
     set_target_required(1);
-	set_helpful_spell(1);
+    set_helpful_spell(1);
 }
 
 void spell_effect(int prof) {
@@ -27,6 +27,11 @@ void spell_effect(int prof) {
         return;
     }
     if (objectp(place)) place = environment(caster);
+	
+    if(!target)
+    {
+        target = caster;
+    }
     /*
     if((int)target->query_property("augmentation")){
       tell_object(caster,"%^YELLOW%^"+target->QCN+" is already under the influence of a similar spell.");

--- a/cmds/spells/o/_owls_wisdom.c
+++ b/cmds/spells/o/_owls_wisdom.c
@@ -12,7 +12,7 @@ void create() {
     set_spell_level(([ "ranger" : 2, "paladin" : 2, "cleric" : 2,"druid" : 2, "mage" : 2 ]));
     set_spell_sphere("alteration");
     set_bonus_type("enhancement");
-    set_syntax("cast CLASS owls wisdom on TARGET");
+    set_syntax("cast CLASS owls wisdom [on TARGET]");
     set_description("This spell allows the caster to infuse their target with the wisdom of an owl, granting them "
 "a +4 enhancement bonus to wisdom.");
     set_verbal_comp();

--- a/cmds/spells/o/_owls_wisdom.c
+++ b/cmds/spells/o/_owls_wisdom.c
@@ -17,8 +17,7 @@ void create() {
 "a +4 enhancement bonus to wisdom.");
     set_verbal_comp();
     set_somatic_comp();
-    set_target_required(1);
-	set_helpful_spell(1);
+    set_helpful_spell(1);
 }
 
 void spell_effect(int prof) {
@@ -27,6 +26,11 @@ void spell_effect(int prof) {
         return;
     }
     if (objectp(place)) place = environment(caster);
+	
+    if(!target)
+    {
+        target = caster;
+    }
 
     if(prof == -100) { // hack for potions. Cuz lib doesn't seem to call reverse spell anymore, and I'm lazy. N, 6/15.
       reverse_spell();


### PR DESCRIPTION
The following spells required a target for some reason, and this PR aims to make it so that a targetless casting instead targets the caster.

Bears Endurance
Bulls Strength
Cats Grace
Eagles Splendor
Foxs Cunning
Owls Wisdom