### PR TITLE
Allow prepare to infer class based on pose

### DIFF
--- a/cmds/mortal/_prepare.c
+++ b/cmds/mortal/_prepare.c
@@ -159,10 +159,15 @@ int cmd_prepare(string str)
         }
     }
 
-    if (sscanf(str, "%s %s", myclass, args) != 2)
-    {
-                HELP_D->help("prepare");
-                return 1;
+    // Ripped from _cast.c, think it should work?
+    if (regexp(str, implode(PLAYER_D->list_classes(), "|") + "|innate|cantrip|deep")) {
+        if (!sscanf(str, "%s %s", myclass, args)) {
+            HELP_D->help("prepare");
+            return 1;
+        }
+    }else {
+        myclass = TP->query_class();
+        args = str;
     }
 
     if(!can_prepare_as(myclass))

--- a/cmds/mortal/_prepare.c
+++ b/cmds/mortal/_prepare.c
@@ -160,7 +160,7 @@ int cmd_prepare(string str)
     }
 
     // Ripped from _cast.c, think it should work?
-    if (regexp(str, implode(PLAYER_D->list_classes(), "|") + "|innate|cantrip|deep")) {
+    if (regexp(str, implode(PLAYER_D->list_classes(), "|"))) {
         if (!sscanf(str, "%s %s", myclass, args)) {
             HELP_D->help("prepare");
             return 1;


### PR DESCRIPTION
Cast can be invoked without specifying a class.
Prepare cannot be, and this PR aims to rectify that.