### PR TITLE
Remove caster's name from dispersal messages

### DIFF
--- a/cmds/spells/h/_hold_monster.c
+++ b/cmds/spells/h/_hold_monster.c
@@ -48,7 +48,7 @@ void spell_effect(int prof) {
         return;
     }
    if (target->query_property("no hold") || target->query_property("no paralyze")) {
-       tell_object(caster,"%^YELLOW%^You spell disperses futilely around "+target->QCN+".\n");
+       tell_object(caster,"%^YELLOW%^Your spell disperses futilely around "+target->QCN+".\n");
       TO->remove();
       return;
    }

--- a/cmds/spells/h/_hold_person.c
+++ b/cmds/spells/h/_hold_person.c
@@ -57,7 +57,7 @@ void spell_effect(int prof)
 
     if (target->query_property("no hold") || target->query_property("no paralyze"))
     {
-        tell_object(caster,"%^YELLOW%^You spell disperses futilely around "+target->QCN+".\n");
+        tell_object(caster,"%^YELLOW%^Your spell disperses futilely around "+target->QCN+".\n");
         dest_effect();
         return;
     }

--- a/std/effects/effect.c
+++ b/std/effects/effect.c
@@ -705,10 +705,10 @@ int is_effect() {
 
 void sendDisbursedMessage(object victim){
 
-    tell_object(victim,"%^BOLD%^%^YELLOW%^"+caster->query_cap_name()+"'s magic disperses futilely around you.");
+    tell_object(victim,"%^BOLD%^%^YELLOW%^A spell disperses futilely around you.");
     if (present(caster,environment(victim)))
         tell_object(caster,"%^BOLD%^%^YELLOW%^Your magic disperses futilely around "+victim->query_cap_name()+".");
-    tell_room(environment(victim),"%^BOLD%^%^YELLOW%^"+caster->query_cap_name()+"'s magic disperses futilely around "+victim->query_cap_name()+".",({ victim, caster}) );
+    tell_room(environment(victim),"%^BOLD%^%^YELLOW%^A spell disperses futilely around "+victim->query_cap_name()+".",({ victim, caster}) );
     return 1;
 }
 

--- a/std/effects/effect.c
+++ b/std/effects/effect.c
@@ -704,11 +704,15 @@ int is_effect() {
 }
 
 void sendDisbursedMessage(object victim){
-
-    tell_object(victim,"%^BOLD%^%^YELLOW%^A spell disperses futilely around you.");
+    if(silent_casting){
+        tell_object(victim,"%^BOLD%^%^YELLOW%^A spell disperses futilely around you.");
+        tell_room(environment(victim),"%^BOLD%^%^YELLOW%^A spell disperses futilely around "+victim->query_cap_name()+".",({ victim, caster}) );
+    } else {
+        tell_object(victim,"%^BOLD%^%^YELLOW%^"+caster->query_cap_name()+"'s magic disperses futilely around you.");
+        tell_room(environment(victim),"%^BOLD%^%^YELLOW%^"+caster->query_cap_name()+"'s magic disperses futilely around "+victim->query_cap_name()+".",({ victim, caster}) );
+    }
     if (present(caster,environment(victim)))
         tell_object(caster,"%^BOLD%^%^YELLOW%^Your magic disperses futilely around "+victim->query_cap_name()+".");
-    tell_room(environment(victim),"%^BOLD%^%^YELLOW%^A spell disperses futilely around "+victim->query_cap_name()+".",({ victim, caster}) );
     return 1;
 }
 

--- a/std/magic/spell.c
+++ b/std/magic/spell.c
@@ -2,6 +2,7 @@
 #include <spell.h>
 #include <magic.h>
 #include <daemons.h>
+#include <schoolspells.h>
 #include <psions.h>
 #include <mysteries.h>
 #include <damage_types.h>

--- a/std/magic/spell.c
+++ b/std/magic/spell.c
@@ -2389,14 +2389,24 @@ void sendDisbursedMessage(object victim)
         return;
     }
     if (objectp(caster)) {
-        tell_object(victim, "%^BOLD%^%^YELLOW%^A " + whatsit + " disperses futilely around you.%^RESET%^");
-        if (present(caster, environment(victim))) {
-            tell_object(caster, "%^BOLD%^%^YELLOW%^Your " + whatsit + " disperses futilely around " + victim->QCN + ".%^RESET%^");
+        if (silent_casting) {
+            tell_object(victim, "%^BOLD%^%^YELLOW%^A " + whatsit + " disperses futilely around you.%^RESET%^");
+            if (present(caster, environment(victim))) {
+                tell_object(caster, "%^BOLD%^%^YELLOW%^Your " + whatsit + " disperses futilely around " + victim->QCN + ".%^RESET%^");
+            }
+            tell_room(environment(victim), "%^BOLD%^%^YELLOW%^A " + whatsit + " disperses futilely around " + victim->QCN + ".", ({ victim, caster }));
+            return 1;
+        } else {
+            tell_object(victim, "%^BOLD%^%^YELLOW%^" + caster->QCN + "'s " + whatsit + " disperses futilely around you.%^RESET%^");
+            if (present(caster, environment(victim))) {
+                tell_object(caster, "%^BOLD%^%^YELLOW%^Your " + whatsit + " disperses futilely around " + victim->QCN + ".%^RESET%^");
+            }
+            tell_room(environment(victim), "%^BOLD%^%^YELLOW%^" + caster->QCN + "'s " + whatsit + " disperses futilely around " + victim->QCN + ".", ({ victim, caster }));
         }
-        tell_room(environment(victim), "%^BOLD%^%^YELLOW%^A " + whatsit + " disperses futilely around " + victim->QCN + ".", ({ victim, caster }));
         return 1;
     }
-    tell_object(victim, "%^BOLD%^%^YELLOW%^The " + whatsit + " disperses futilely around you.%^RESET%^");
+
+    tell_object(victim, "%^BOLD%^%^YELLOW%^A " + whatsit + " disperses futilely around you.%^RESET%^");
     tell_room(environment(victim), "%^BOLD%^%^YELLOW%^A " + whatsit + " disperses futilely around " + victim->QCN + ".", ({ victim }));
     return 1;
 }

--- a/std/magic/spell.c
+++ b/std/magic/spell.c
@@ -2,7 +2,6 @@
 #include <spell.h>
 #include <magic.h>
 #include <daemons.h>
-#include <schoolspells.h>
 #include <psions.h>
 #include <mysteries.h>
 #include <damage_types.h>
@@ -2389,15 +2388,15 @@ void sendDisbursedMessage(object victim)
         return;
     }
     if (objectp(caster)) {
-        tell_object(victim, "%^BOLD%^%^YELLOW%^" + caster->QCN + "'s " + whatsit + " disperses futilely around you.%^RESET%^");
+        tell_object(victim, "%^BOLD%^%^YELLOW%^A " + whatsit + " disperses futilely around you.%^RESET%^");
         if (present(caster, environment(victim))) {
             tell_object(caster, "%^BOLD%^%^YELLOW%^Your " + whatsit + " disperses futilely around " + victim->QCN + ".%^RESET%^");
         }
-        tell_room(environment(victim), "%^BOLD%^%^YELLOW%^" + caster->QCN + "'s " + whatsit + " disperses futilely around " + victim->QCN + ".", ({ victim, caster }));
+        tell_room(environment(victim), "%^BOLD%^%^YELLOW%^A " + whatsit + " disperses futilely around " + victim->QCN + ".", ({ victim, caster }));
         return 1;
     }
     tell_object(victim, "%^BOLD%^%^YELLOW%^The " + whatsit + " disperses futilely around you.%^RESET%^");
-    tell_room(environment(victim), "%^BOLD%^%^YELLOW%^The " + whatsit + " cast from a dead or unknown source disperses futilely around " + victim->QCN + ".", ({ victim }));
+    tell_room(environment(victim), "%^BOLD%^%^YELLOW%^A " + whatsit + " disperses futilely around " + victim->QCN + ".", ({ victim }));
     return 1;
 }
 

--- a/std/magic/spell.c
+++ b/std/magic/spell.c
@@ -2395,7 +2395,6 @@ void sendDisbursedMessage(object victim)
                 tell_object(caster, "%^BOLD%^%^YELLOW%^Your " + whatsit + " disperses futilely around " + victim->QCN + ".%^RESET%^");
             }
             tell_room(environment(victim), "%^BOLD%^%^YELLOW%^A " + whatsit + " disperses futilely around " + victim->QCN + ".", ({ victim, caster }));
-            return 1;
         } else {
             tell_object(victim, "%^BOLD%^%^YELLOW%^" + caster->QCN + "'s " + whatsit + " disperses futilely around you.%^RESET%^");
             if (present(caster, environment(victim))) {

--- a/std/magic/spell.c
+++ b/std/magic/spell.c
@@ -2392,15 +2392,15 @@ void sendDisbursedMessage(object victim)
         if (silent_casting) {
             tell_object(victim, "%^BOLD%^%^YELLOW%^A " + whatsit + " disperses futilely around you.%^RESET%^");
             if (present(caster, environment(victim))) {
-                tell_object(caster, "%^BOLD%^%^YELLOW%^Your " + whatsit + " disperses futilely around " + victim->QCN + ".%^RESET%^");
+                tell_object(caster, "%^BOLD%^%^YELLOW%^Your " + whatsit + " disperses futilely around " + victim->query_cap_name() + ".%^RESET%^");
             }
-            tell_room(environment(victim), "%^BOLD%^%^YELLOW%^A " + whatsit + " disperses futilely around " + victim->QCN + ".", ({ victim, caster }));
+            tell_room(environment(victim), "%^BOLD%^%^YELLOW%^A " + whatsit + " disperses futilely around " + victim->query_cap_name() + ".", ({ victim, caster }));
         } else {
-            tell_object(victim, "%^BOLD%^%^YELLOW%^" + caster->QCN + "'s " + whatsit + " disperses futilely around you.%^RESET%^");
+            tell_object(victim, "%^BOLD%^%^YELLOW%^" + caster->query_cap_name() + "'s " + whatsit + " disperses futilely around you.%^RESET%^");
             if (present(caster, environment(victim))) {
-                tell_object(caster, "%^BOLD%^%^YELLOW%^Your " + whatsit + " disperses futilely around " + victim->QCN + ".%^RESET%^");
+                tell_object(caster, "%^BOLD%^%^YELLOW%^Your " + whatsit + " disperses futilely around " + victim->query_cap_name() + ".%^RESET%^");
             }
-            tell_room(environment(victim), "%^BOLD%^%^YELLOW%^" + caster->QCN + "'s " + whatsit + " disperses futilely around " + victim->QCN + ".", ({ victim, caster }));
+            tell_room(environment(victim), "%^BOLD%^%^YELLOW%^" + caster->query_cap_name() + "'s " + whatsit + " disperses futilely around " + victim->query_cap_name() + ".", ({ victim, caster }));
         }
         return 1;
     }


### PR DESCRIPTION
As per a recently archived conversation, this PR removes the caster's name from spell dispersal messages in order to keep undetectably cast spells anonymous.

It's also a bit dirty and includes some accidental typo fixes.

Note that this does *not* remove the casters name from spell reflection -- I am making the bold assumption that such a thing works physically differently than a spell fizzling on a ward.