### PR TITLE
Updates attacks of opportunity against casters

### DIFF
--- a/cmds/feats/c/_combat_reflexes.c
+++ b/cmds/feats/c/_combat_reflexes.c
@@ -9,7 +9,7 @@ void create() {
     feat_category("MeleeDamage");
     feat_name("combat reflexes");
     feat_prereq("Thief L4");
-    feat_desc("Combat reflexes represents the highly trained speed and dexterity of the rogue in combat, allowing them to perform attacks of opportunity, both when their opponent casts spells at them and when their opponent tries to flee or escape.%^RESET%^");
+    feat_desc("Combat reflexes represents the highly trained speed and dexterity of the rogue in combat, allowing them to perform attacks of opportunity, both when their opponent casts spells and when their opponent tries to flee or escape.%^RESET%^");
     permanent(1);
 }
 

--- a/cmds/feats/s/_spell_counterstrike.c
+++ b/cmds/feats/s/_spell_counterstrike.c
@@ -12,9 +12,9 @@ void create()
     feat_name("spell counterstrike");
     feat_prereq("Magus L16");
     feat_classes("magus");
-    feat_desc("At 16th level, whenever an enemy of the magus successfully casts a spell, that enemy provokes an attack of opportunity from the magus, sometimes two.
+    feat_desc("At 16th level, whenever an enemy of the magus successfully casts a spell, that enemy provokes an attack of opportunity from the magus.
 
-If a character has both the spell counterstrike feat and the spellbreaker feat they will perform three attacks of opportunity.");
+Stacks with similar feats.");
     permanent(1);
 }
 

--- a/cmds/feats/s/_spellbreaker.c
+++ b/cmds/feats/s/_spellbreaker.c
@@ -10,7 +10,7 @@ void create()
     feat_category("MagicResistance");
     feat_name("spellbreaker");
     feat_prereq("Disruptive, Fighter L10");
-    feat_desc("You extend your wards, allowing yourself to make an attack of opportunity, sometimes two, whenever enemy casts a spell at you.
+    feat_desc("You extend your wards, allowing yourself to make an attack of opportunity whenever enemy casts a spell at you.
 
 %^BOLD%^N.B.%^RESET%^ Stacks with similar feats.");
     permanent(1);

--- a/cmds/feats/s/_spellbreaker.c
+++ b/cmds/feats/s/_spellbreaker.c
@@ -12,7 +12,7 @@ void create()
     feat_prereq("Disruptive, Fighter L10");
     feat_desc("You extend your wards, allowing yourself to make an attack of opportunity, sometimes two, whenever enemy casts a spell at you.
 
-%^BOLD%^N.B.%^RESET%^ If a character has both the spell counterstrike feat and the spellbreaker feat they will perform three attacks of opportunity.");
+%^BOLD%^N.B.%^RESET%^ Stacks with similar feats.");
     permanent(1);
     allow_blind(1);
 }

--- a/cmds/feats/s/_spellbreaker.c
+++ b/cmds/feats/s/_spellbreaker.c
@@ -10,7 +10,7 @@ void create()
     feat_category("MagicResistance");
     feat_name("spellbreaker");
     feat_prereq("Disruptive, Fighter L10");
-    feat_desc("You extend your wards, allowing yourself to make an attack of opportunity whenever enemy casts a spell at you.
+    feat_desc("Your instincts sharpen, allowing you to make an attack of opportunity whenever enemy casts a spell.
 
 %^BOLD%^N.B.%^RESET%^ Stacks with similar feats.");
     permanent(1);

--- a/std/magic/spell.c
+++ b/std/magic/spell.c
@@ -692,10 +692,6 @@ void receive_opportunity_attacks()
     {
         return 0;
     }
-    if ((int)TO->query_helpful())
-    {
-        return 0;
-    }
     
     for (int i = 0; i < sizeof(attackers); ++i )
     {

--- a/std/magic/spell.c
+++ b/std/magic/spell.c
@@ -684,9 +684,46 @@ void query_blood_magic()
     return blood_magic;
 }
 
+void receive_opportunity_attacks()
+{
+    object* attackers = caster->query_attackers();
+    
+    if (!objectp(caster))
+    {
+        return 0;
+    }
+    if ((int)TO->query_helpful())
+    {
+        return 0;
+    }
+    
+    for (int i = 0; i < sizeof(attackers); ++i )
+    {
+        if (attackers[i] == caster) // Probably redundant.
+        {
+            continue;
+        }
+        if (FEATS_D->usable_feat(attackers[i], "spell counterstrike"))
+        {
+            attackers[i]->kill_ob(caster);
+            attackers[i] && caster && attackers[i]->execute_attack();
+        }
+        if (FEATS_D->usable_feat(attackers[i], "spellbreaker"))
+        {
+            attackers[i]->kill_ob(caster);
+            attackers[i] && caster && attackers[i]->execute_attack();
+        }
+        if(FEATS_D->usable_feat(attackers[i], "combat reflexes"))
+        {
+            attackers[i]->kill_ob(caster);
+            attackers[i] && caster && attackers[i]->execute_attack();
+        }
+    }
+}
+
 int check_reflection()
 {
-    int turnperc, flagz, counters, can_spend;
+    int turnperc, flagz, can_spend;
     object temp;
 
     if (!objectp(caster)) {
@@ -723,33 +760,6 @@ int check_reflection()
     }
     else {
         turnperc = target->query_spellTurning();
-    }
-
-    counters = 0 ;
-    if (FEATS_D->usable_feat(target, "spell counterstrike")) {
-        counters += 1;
-    }
-    if (FEATS_D->usable_feat(target, "spellbreaker")) {
-        counters += 1;
-    }
-    if(FEATS_D->usable_feat(target, "combat reflexes"))
-        counters += 1;
-
-    //Venger: with a single feat is 1 counter and a chance to counter again.
-    //with both feats is 3 counters instead of doubling the counters.
-    if (counters) {
-        spell_kill(target, caster);
-        for(int x = 0; x < counters; x++)
-            target && caster && target->execute_attack();
-        /*
-        target->execute_attack();
-        if (counters > 1) {
-            target->execute_attack();
-            target->execute_attack();
-        }else if (!random(3)) {
-                target->execute_attack();
-        }
-        */
     }
     /*
     switch (flagz) {
@@ -1418,6 +1428,8 @@ void wizard_interface(object user, string type, string targ)
 
     tell_object(caster, "You begin to " + whatdo + " " + spell_name + "!");
 
+    receive_opportunity_attacks()
+    
     // this is needed for PCs, uses different function than mobs
     if (objectp(target)) {
         check_reflection();


### PR DESCRIPTION
This PR seeks to:
Make help files for Spell Counterstrike and Spellbreaker more truthful.
Add opportunity attacks against *all* enemy casts, as opposed to just targeted ones.

-----

Relevant snippet here:
https://discord.com/channels/818872385289060382/818929770157965352/976279376968699914