### PR TITLE
Improved and Greater Spell Power feats clarification

### DIFF
--- a/cmds/feats/g/_greater_spell_power.c
+++ b/cmds/feats/g/_greater_spell_power.c
@@ -10,7 +10,7 @@ void create()
     feat_category("MagicDamage");
     feat_name("greater spell power");
     feat_prereq("Improved spell power");
-    feat_desc("With this feat, the caster gains +3 to caster level with all spells.");
+    feat_desc("With this feat, the caster gains an additional +1 to caster level with all spells.");
     permanent(1);
     set_required_for(({"magic arsenal"}));
 }

--- a/cmds/feats/i/_improved_spell_power.c
+++ b/cmds/feats/i/_improved_spell_power.c
@@ -10,7 +10,7 @@ void create()
     feat_category("MagicDamage");
     feat_name("improved spell power");
     feat_prereq("Spell power");
-    feat_desc("With this feat, the caster gains +2 to caster level with all spells.");
+    feat_desc("With this feat, the caster gains an additional +1 to caster level with all spells.");
     permanent(1);
     set_required_for(({"greater spell power","magic arsenal"}));
 }


### PR DESCRIPTION
The wording on the Spell Power feats is a little confusing, because one might assume +1, +2, and +3 add up to +6, but actually, all three of them total to +3. I changed the wording to "an additional +1" to be consistent with the Resistance feats.